### PR TITLE
Add planned path waypoint and time remaining packet

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -787,6 +787,12 @@
                     "dataType": "UINT32_T",
                     "dataCount": 2,
                     "comments": "[Thread Enum ID, FPS Value]"
+                },
+                "PathWaypoints": {
+                    "dataId": 11104,
+                    "dataType": "DOUBLE_T",
+                    "dataCount": 1000,
+                    "comments": "[Lat, Lon, Lat, Lon, ...]"
                 }
             },
             "Error": {},

--- a/manifest.json
+++ b/manifest.json
@@ -793,6 +793,12 @@
                     "dataType": "DOUBLE_T",
                     "dataCount": 1000,
                     "comments": "[Lat, Lon, Lat, Lon, ...]"
+                },
+                "TimeRemaining": {
+                    "dataId": 11105,
+                    "dataType": "DOUBLE_T",
+                    "dataCount": 1,
+                    "comments": "Estimated time remaining in seconds to reach goal."
                 }
             },
             "Error": {},


### PR DESCRIPTION
Added a "PathWaypoints" packet to Autonomy Telemetry, which sends a list of latitude and longitude doubles representing the waypoints that Autonomy generated for the path. This packet is received by Basestation to display the path on the map.

Also added a "TimeRemaining" packet to Autonomy Telemetry which is used to send the estimated time remaining in seconds to reach goal waypoint. This time is used by the Basestation map to display the ETA of completion.